### PR TITLE
Fix validator rewards vulnerability and cleanup workspace

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,5 @@ members = [
 	"d9-treasury/",
 	"d9-node-rewards",
 	"d9-council-lock",
-    "d9-multi-sig",
-    "d9-transaction-fees"
+    "d9-multi-sig"
 ]

--- a/d9-node-voting/Cargo.toml
+++ b/d9-node-voting/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pallet-d9-node-voting"
-version = "1.3.0"
+version = "1.3.1"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/d9-node-voting/src/lib.rs
+++ b/d9-node-voting/src/lib.rs
@@ -727,10 +727,15 @@ pub mod pallet {
         }
 
         fn end_session(end_index: SessionIndex) {
+            // Get validator vote stats before draining - these are the actual validators
+            let validators_with_votes: Vec<(T::AccountId, u64)> = CurrentValidatorVoteStats::<T>::iter()
+                .map(|(validator, stats)| (validator, stats.total_votes))
+                .collect();
+            
             let _ = CurrentValidatorVoteStats::<T>::drain();
-            let sorted_nodes_with_votes = Self::get_sorted_candidates_with_votes();
 
-            let _ = T::NodeRewardManager::update_rewards(end_index, sorted_nodes_with_votes);
+            // Only pass validators (not all candidates) to receive rewards
+            let _ = T::NodeRewardManager::update_rewards(end_index, validators_with_votes);
             let _ = T::ReferendumManager::end_active_votes(end_index);
         }
     }


### PR DESCRIPTION
- Fix security issue where non-validators could receive rewards
- Only pass active validators from CurrentValidatorVoteStats to NodeRewardManager
- Bump d9-node-voting version from 1.3.0 to 1.3.1
- Remove non-existent d9-transaction-fees from workspace