### PR TITLE
Revert node reward distribution to use sorted candidates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1811,7 +1811,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-d9-node-voting"
-version = "1.3.0"
+version = "1.3.2"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -1850,22 +1850,6 @@ dependencies = [
  "scale-info",
  "serde",
  "sp-api",
- "sp-core",
- "sp-io",
- "sp-runtime",
- "sp-std 5.0.0",
-]
-
-[[package]]
-name = "pallet-d9-transaction-fees"
-version = "1.0.0"
-dependencies = [
- "frame-support",
- "frame-system",
- "pallet-transaction-payment",
- "parity-scale-codec",
- "scale-info",
- "serde",
  "sp-core",
  "sp-io",
  "sp-runtime",
@@ -1937,7 +1921,6 @@ dependencies = [
  "frame-system",
  "parity-scale-codec",
  "scale-info",
- "serde",
  "sp-core",
  "sp-io",
  "sp-runtime",

--- a/d9-node-voting/Cargo.toml
+++ b/d9-node-voting/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pallet-d9-node-voting"
-version = "1.3.1"
+version = "1.3.2"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/d9-node-voting/src/lib.rs
+++ b/d9-node-voting/src/lib.rs
@@ -727,15 +727,10 @@ pub mod pallet {
         }
 
         fn end_session(end_index: SessionIndex) {
-            // Get validator vote stats before draining - these are the actual validators
-            let validators_with_votes: Vec<(T::AccountId, u64)> = CurrentValidatorVoteStats::<T>::iter()
-                .map(|(validator, stats)| (validator, stats.total_votes))
-                .collect();
-            
             let _ = CurrentValidatorVoteStats::<T>::drain();
+            let sorted_nodes_with_votes = Self::get_sorted_candidates_with_votes();
 
-            // Only pass validators (not all candidates) to receive rewards
-            let _ = T::NodeRewardManager::update_rewards(end_index, validators_with_votes);
+            let _ = T::NodeRewardManager::update_rewards(end_index, sorted_nodes_with_votes);
             let _ = T::ReferendumManager::end_active_votes(end_index);
         }
     }


### PR DESCRIPTION
This commit reverts the recent change that distributed rewards directly to validators without sorting. The original implementation properly sorted candidates by vote count before reward distribution, ensuring fair and predictable reward allocation based on performance.

Changes:
- Restore get_sorted_candidates_with_votes() call in end_session
- Remove direct validator iteration without sorting
- Ensure rewards are distributed based on vote ranking

This maintains the intended economic incentives where nodes with higher vote counts receive rewards first.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the package version to 1.3.2.

* **Refactor**
  * Improved the process for obtaining and sorting nodes with votes during session end, streamlining internal reward updates. No changes to user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->